### PR TITLE
replace deprecated parameter

### DIFF
--- a/public.tf
+++ b/public.tf
@@ -116,7 +116,7 @@ resource "aws_route_table_association" "public" {
 
 resource "aws_eip" "public" {
   for_each = local.public_nat_gateway_azs
-  vpc      = true
+  domain   = "vpc"
   tags     = module.public_label.tags
 
   lifecycle {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## what

Replace
```
vpc = "true"
```
with
```
domain = "vpc"
```
for `aws_eip` resource.

## why

`vpc` is deprecated in favor of `domain`.

